### PR TITLE
Always unlock step motor on undefined state

### DIFF
--- a/include/Conveyor.hpp
+++ b/include/Conveyor.hpp
@@ -43,7 +43,6 @@ class Conveyor {
   ConveyorStatus m_currentStatus;
 #ifdef HARDWARE_GRBL
   Module_GRBL m_grbl;
-  TwoWire *m_wire;
 #else
   int m_motorDelay;
 #endif  // defined(HARDWARE_GRBL)

--- a/include/TagReader.hpp
+++ b/include/TagReader.hpp
@@ -1,12 +1,25 @@
 #ifndef TAG_READER_HPP
 #define TAG_READER_HPP
 
+#ifdef HARDWARE_MFRC522
+#include <MFRC522.h>
+#elif defined(HARDWARE_MFRC522_I2C)
+#include <MFRC522_I2C.h>
+#endif
+
 class TagReader {
  public:
   TagReader() = default;
-  ~TagReader() = default;
+  ~TagReader();
 
+#ifdef HARDWARE_MFRC522_I2C
+  /// @brief Delayed initialization of the tag reader
+  /// @param Wire The I2C bus.
+  void begin(TwoWire *Wire);
+#else
+  /// @brief Delayed initialization of the tag reader
   void begin();
+#endif  // defined(HARDWARE_MFRC522_I2C)
 
   bool isNewTagPresent();
 
@@ -14,6 +27,13 @@ class TagReader {
   /// @param buffer The buffer to copy the tag data to, MUST BE AT LEAST 10 BYTES.
   /// @return The number of bytes copied to the buffer, or 0 if no tag was read.
   unsigned char readTag(unsigned char *buffer);
+
+ private:
+#ifdef HARDWARE_MFRC522_I2C
+  MFRC522_I2C *m_mfrc522;
+#elif defined(HARDWARE_MFRC522)
+  MFRC522 *m_mfrc522;
+#endif
 };
 
 #endif  // !defined(TAG_READER_HPP)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,7 +57,9 @@ void setup() {
   xTaskCreatePinnedToCore(&readButtons, "readButtons", 4096, nullptr, 8, nullptr, 0);
   xTaskCreatePinnedToCore(&runConveyor, "runConveyor", 4096, nullptr, 8, nullptr, 0);
   xTaskCreatePinnedToCore(&pickRandomDirection, "pickRandomDirection", 4096, nullptr, 8, nullptr, 0);
+#if defined(HARDWARE_MFRC522) || defined(HARDWARE_MFRC522_I2C)
   xTaskCreatePinnedToCore(&readAndPrintTags, "readAndPrintTags", 4096, nullptr, 8, nullptr, 0);
+#endif
   xTaskCreatePinnedToCore(&makeHttpRequests, "makeHttpRequests", 4096, nullptr, 8, nullptr, 1);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,8 +2,6 @@
 
 #ifdef ENV_M5STACK
 #include <M5Stack.h>
-#else
-#include <SPI.h>
 #endif  // defined(ENV_M5STACK)
 
 #include "Buttons.hpp"
@@ -31,17 +29,29 @@ void setup() {
   M5.begin();             // Init M5Stack.
   M5.Power.begin();       // Init power
   M5.lcd.setTextSize(2);  // Set the text size to 2.
-  Wire.begin(21, 22);     // Wire init, adding the I2C bus.
-  conveyor.begin(&Wire);
+  Wire.begin(21, 22);
   M5.Lcd.println("= Motor Test =");
   M5.Lcd.println("A: Start B: Status C: Stop");
 #else
   conveyor.begin();
   Serial.flush();
 #endif
-  buttons.begin();
+
+#ifdef HARDWARE_GRBL
   sorter.begin();
+  conveyor.begin(&Wire);
+#else
+  sorter.begin();
+  conveyor.begin();
+#endif
+
+#ifdef HARDWARE_MFRC522_I2C
+  tagReader.begin(&Wire);
+#else
   tagReader.begin();
+#endif
+
+  buttons.begin();
   printStatus();
 
   xTaskCreatePinnedToCore(&readButtons, "readButtons", 4096, nullptr, 8, nullptr, 0);


### PR DESCRIPTION
Fix issue where the step motor / conveyor would sometimes be stuck in a `ALARM` state.
When reading a state other than `IDLE` or `BUSY` from the motor, force unlock it and read the status again.

Closes #28