### PR TITLE
Manage maintenance mode

### DIFF
--- a/include/ActiveModule.hpp
+++ b/include/ActiveModule.hpp
@@ -1,15 +1,8 @@
-#ifndef ACTIVEMODULE_HPP
-#define ACTIVEMODULE_HPP
+#ifndef ACTIVE_MODULE_HPP
+#define ACTIVE_MODULE_HPP
 
-
-enum class ActiveModule {
-  NONE=0,
-  CONVEYOR,
-  SORTER,
-  TAG_READER,
-  DOLIBARR
-};
+enum class ActiveModule { NONE = 0, CONVEYOR, SORTER, TAG_READER, DOLIBARR };
 
 static char const *ACTIVE_MODULES[5] = {"NONE", "CONVEYOR", "SORTER", "TAG_READER", "DOLIBARR"};
 
-#endif // !defined(ACTIVEMODULE_HPP)
+#endif  // !defined(ACTIVE_MODULE_HPP)

--- a/include/ActiveModule.hpp
+++ b/include/ActiveModule.hpp
@@ -1,0 +1,15 @@
+#ifndef ACTIVEMODULE_HPP
+#define ACTIVEMODULE_HPP
+
+
+enum class ActiveModule {
+  NONE=0,
+  CONVEYOR,
+  SORTER,
+  TAG_READER,
+  DOLIBARR
+};
+
+static char const *ACTIVE_MODULES[5] = {"NONE", "CONVEYOR", "SORTER", "TAG_READER", "DOLIBARR"};
+
+#endif // !defined(ACTIVEMODULE_HPP)

--- a/include/Sorter.hpp
+++ b/include/Sorter.hpp
@@ -15,6 +15,7 @@ class Sorter {
 
   void begin();
   void move(SorterDirection direction);
+  void moveWithSpecificAngle(int angle);
 };
 
 #endif  // !defined(SORTER_HPP)

--- a/include/TaskContext.hpp
+++ b/include/TaskContext.hpp
@@ -1,10 +1,11 @@
 #ifndef TASK_CONTEXT_HPP
 #define TASK_CONTEXT_HPP
 
-#include <ActiveModule.hpp>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #include <freertos/task.h>
+
+#include <ActiveModule.hpp>
 
 #include "OperationMode.hpp"
 
@@ -68,9 +69,7 @@ class TaskContext {
 
   constexpr ActiveModule getCurrentMaintenanceModule() const { return m_currentActiveModule; }
 
-  void setMaintenanceActiveModule(ActiveModule newActiveModule) {
-    m_currentActiveModule = newActiveModule;
-  }
+  void setMaintenanceActiveModule(ActiveModule newActiveModule) { m_currentActiveModule = newActiveModule; }
 
   /** @} */  // end of TaskContextOperationModeSwitcherAPI
 

--- a/include/TaskContext.hpp
+++ b/include/TaskContext.hpp
@@ -1,6 +1,7 @@
 #ifndef TASK_CONTEXT_HPP
 #define TASK_CONTEXT_HPP
 
+#include <ActiveModule.hpp>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #include <freertos/task.h>
@@ -65,10 +66,17 @@ class TaskContext {
   /// @return The requested operation mode, or OperationMode::UNDEFINED if no mode change has been requested yet.
   constexpr OperationMode getRequestedOperationMode() const { return m_requestedMode; }
 
+  constexpr ActiveModule getCurrentMaintenanceModule() const { return m_currentActiveModule; }
+
+  void setMaintenanceActiveModule(ActiveModule newActiveModule) {
+    m_currentActiveModule = newActiveModule;
+  }
+
   /** @} */  // end of TaskContextOperationModeSwitcherAPI
 
  private:
   Hardware *m_hardware;
+  ActiveModule m_currentActiveModule;
 
   // Sub-task management internal state
   bool m_allowSubTaskCreation;

--- a/include/TheTranslationConfig.hpp
+++ b/include/TheTranslationConfig.hpp
@@ -55,4 +55,9 @@
 #define DOLIBARR_ENDPOINT_STOCKMOVEMENTS "/stockmovements"
 #pragma endregion "dolibarr configuration"
 
+#pragma region "maintenance mode"
+#define HOLD_BUTTON_TIME 3000
+#define CHANGE_ANGLE_DELAY 30
+#pragma endregion "maintenance mode"
+
 #endif  // !defined(THE_TRANSLATION_CONFIG_HPP)

--- a/src/Sorter.cpp
+++ b/src/Sorter.cpp
@@ -31,9 +31,7 @@ void Sorter::move(SorterDirection direction) {
   }
 }
 
-void Sorter::moveWithSpecificAngle(int angle) {
-  goPlus.Servo_write_angle(SORTER_SERVO_NUMBER,angle);
-}
+void Sorter::moveWithSpecificAngle(int angle) { goPlus.Servo_write_angle(SORTER_SERVO_NUMBER, angle); }
 
 #else
 

--- a/src/Sorter.cpp
+++ b/src/Sorter.cpp
@@ -31,6 +31,10 @@ void Sorter::move(SorterDirection direction) {
   }
 }
 
+void Sorter::moveWithSpecificAngle(int angle) {
+  goPlus.Servo_write_angle(SORTER_SERVO_NUMBER,angle);
+}
+
 #else
 
 void Sorter::begin() {

--- a/src/maintenance.cpp
+++ b/src/maintenance.cpp
@@ -128,13 +128,13 @@ static void startSorter(TaskContext *ctx) {
           while(realPosition < angle) {
             sorter.moveWithSpecificAngle(realPosition);
             realPosition += 1;
-            vTaskDelay(30);
+            interruptibleTaskPauseMs(30);
           }
         } else if(realPosition > angle) {
           while(realPosition > angle) {
             sorter.moveWithSpecificAngle(realPosition);
             realPosition -= 1;
-            vTaskDelay(30);
+            interruptibleTaskPauseMs(30);
           }
         }
       }

--- a/src/maintenance.cpp
+++ b/src/maintenance.cpp
@@ -133,17 +133,16 @@ static void startSorter(TaskContext *ctx) {
       } else if (buttons.BtnB->wasPressed()) {
         M5.Lcd.println("MOVE");
         if (realPosition < angle) {
-          while (realPosition < angle) {
+          do {
             sorter.moveWithSpecificAngle(realPosition);
             realPosition += 1;
-            interruptibleTaskPauseMs(CHANGE_ANGLE_DELAY);
-          }
+          } while (realPosition < angle && interruptibleTaskPauseMs(CHANGE_ANGLE_DELAY));
+
         } else if (realPosition > angle) {
-          while (realPosition > angle) {
+          do {
             sorter.moveWithSpecificAngle(realPosition);
             realPosition -= 1;
-            interruptibleTaskPauseMs(CHANGE_ANGLE_DELAY);
-          }
+          } while (realPosition > angle && interruptibleTaskPauseMs(CHANGE_ANGLE_DELAY));
         }
       }
       if (buttons.BtnB->pressedFor(HOLD_BUTTON_TIME)) {

--- a/src/maintenance.cpp
+++ b/src/maintenance.cpp
@@ -12,18 +12,230 @@
 #include "Hardware.hpp"
 #include "Logger.hpp"
 #include "taskUtil.hpp"
+#include "ActiveModule.hpp"
+#include "TheTranslationConfig.hpp"
 
-[[deprecated("TEMPORARY CODE: replace with actual maintenance routines")]]
-static void temporaryFakeMaintenanceModeTask(TaskContext *ctx) {
+static void selectMode(TaskContext *ctx) {
   Buttons &buttons = ctx->getHardware()->buttons;
+  int range = 1;
+  LOG_DEBUG("[MAINT.] Active Module : %s\n", ACTIVE_MODULES[static_cast<int>(ctx->getCurrentMaintenanceModule())]);
+  do {
+    if(ctx->getCurrentMaintenanceModule() == ActiveModule::NONE) {
+      buttons.update();
+      if (buttons.BtnA->wasPressed()) {
+        LOG_DEBUG("[BTN] A pressed\n");
+        if (range > 1) {
+          range -= 1;
+          // clearScreen();
+          M5.Lcd.clearDisplay();
+          M5.Lcd.setCursor(0,0);
+          M5.Lcd.println("Maintenance Mode");
+          M5.Lcd.println("A: < B: OK C: >");
+          M5.Lcd.println(ACTIVE_MODULES[range]);
+        }
+      } else if (buttons.BtnC->wasPressed()) {
+        LOG_DEBUG("[BTN] C pressed\n");
+        if (range < 4 ) {
+          range += 1;
+          // clearScreen();
+          M5.Lcd.clearDisplay();
+          M5.Lcd.setCursor(0,0);
+          M5.Lcd.println("Maintenance Mode");
+          M5.Lcd.println("A: < B: OK C: >");
+          M5.Lcd.println(ACTIVE_MODULES[range]);
+        }
+      }
+      if (buttons.BtnB->wasPressed()) {
+        LOG_DEBUG("[BTN] B pressed\n");
+        switch(range) {
+          case 1 : ctx->setMaintenanceActiveModule(ActiveModule::CONVEYOR); break;
+          case 2 : ctx->setMaintenanceActiveModule(ActiveModule::SORTER); break;
+          case 3 : ctx->setMaintenanceActiveModule(ActiveModule::TAG_READER); break;
+          case 4 : ctx->setMaintenanceActiveModule(ActiveModule::DOLIBARR); break;
+          case 0 :
+          default:  ctx->setMaintenanceActiveModule(ActiveModule::NONE);
+        }
+        // clearScreen();
+        M5.Lcd.clearDisplay();
+        M5.Lcd.setCursor(0,0);
+        M5.Lcd.println("Maintenance Mode for: ");
+        M5.Lcd.println(ACTIVE_MODULES[range]);
+        LOG_DEBUG("[MAINT.] Changing module: %s\n", ACTIVE_MODULES[range]);
+        range = 1;
+      }
+
+      if(buttons.BtnC->pressedFor(3000)) {
+        LOG_DEBUG("[MODE] Exit maintenance mode \n");
+        ctx->requestOperationModeChange(OperationMode::CONFIGURATION);
+      }
+    }
+  } while(interruptibleTaskPauseMs(BUTTONS_READ_INTERVAL));
+}
+
+static void runConveyor(TaskContext *ctx) {
+  Buttons &buttons = ctx->getHardware()->buttons;
+  Conveyor &conveyor = ctx->getHardware()->conveyor;
+  do {
+    if(ctx->getCurrentMaintenanceModule() == ActiveModule::CONVEYOR) {
+      buttons.update();
+      conveyor.update();
+      if(buttons.BtnA->wasPressed()) {
+        LOG_DEBUG("[CONV.] RUN CONVEYOR \n");
+        M5.Lcd.println("RUN MOTOR"); // TODO ML manage speed
+        conveyor.start();
+      } else if(buttons.BtnC->wasPressed()) {
+        M5.Lcd.println("STOP MOTOR");
+        conveyor.stop();
+      }
+
+      if(buttons.BtnB->pressedFor(3000)) {
+        LOG_DEBUG("[MAINT.] Exit module %s\n",ACTIVE_MODULES[1]);
+        ctx->setMaintenanceActiveModule(ActiveModule::NONE);
+        // clearScreen();
+        M5.Lcd.clearDisplay();
+        M5.Lcd.setCursor(0,0);
+        M5.Lcd.println("Maintenance Mode");
+        M5.Lcd.println("A: < B: OK C: >");
+      }
+    }
+  } while (interruptibleTaskPauseMs(BUTTONS_READ_INTERVAL));
+}
+
+static void startSorter(TaskContext *ctx) {
+  Buttons &buttons = ctx->getHardware()->buttons;
+  Sorter &sorter = ctx->getHardware()->sorter;
+
+  int angle = 50;
+  int realPosition = 0;
+  do {
+    if(ctx->getCurrentMaintenanceModule() == ActiveModule::SORTER) {
+      buttons.update();
+      if(buttons.BtnC->wasPressed()) {
+        LOG_INFO("[SORT.] INCREASE ANGLE \n");
+        angle += 1;
+        // clearScreen();
+        M5.Lcd.clearDisplay();
+        M5.Lcd.setCursor(0,0);
+        M5.Lcd.println("ANGLE : ");
+        M5.Lcd.print(angle);
+
+      } else if(buttons.BtnA->wasPressed()) {
+        LOG_INFO("[SORT.] DECREASE ANGLE \n");
+        angle -= 1;
+        // clearScreen();
+        M5.Lcd.clearDisplay();
+        M5.Lcd.setCursor(0,0);
+        M5.Lcd.println("ANGLE : ");
+        M5.Lcd.print(angle);
+      } else if(buttons.BtnB->wasPressed()) {
+        M5.Lcd.println("MOVE");
+        if(realPosition < angle) {
+          while(realPosition < angle) {
+            sorter.moveWithSpecificAngle(realPosition);
+            realPosition += 1;
+            vTaskDelay(30);
+          }
+        } else if(realPosition > angle) {
+          while(realPosition > angle) {
+            sorter.moveWithSpecificAngle(realPosition);
+            realPosition -= 1;
+            vTaskDelay(30);
+          }
+        }
+      }
+      if(buttons.BtnB->pressedFor(3000)) {
+        LOG_DEBUG("[MAINT.] Exit module %s\n",ACTIVE_MODULES[1]);
+        ctx->setMaintenanceActiveModule(ActiveModule::NONE);
+        // clearScreen();
+        M5.Lcd.clearDisplay();
+        M5.Lcd.setCursor(0,0);
+        M5.Lcd.println("Maintenance Mode");
+        M5.Lcd.println("A: < B: OK C: >");
+      }
+    }
+  } while(interruptibleTaskPauseMs(BUTTONS_READ_INTERVAL));
+}
+
+static void readAndPrintTags(TaskContext *ctx) {
+  Buttons &buttons = ctx->getHardware()->buttons;
+  TagReader &tagReader = ctx->getHardware()->tagReader;
+  String tag = "";
 
   do {
-    buttons.update();
-    if (buttons.BtnB->wasPressed()) {
-      LOG_DEBUG("[BTN] B pressed\n");
-      ctx->requestOperationModeChange(OperationMode::CONFIGURATION);
+    if(ctx->getCurrentMaintenanceModule() == ActiveModule::TAG_READER) {
+      buttons.update();
+      if(buttons.BtnA->wasPressed()) {
+        LOG_DEBUG("[TAG.] RUN TAG_READER \n");
+        M5.Lcd.println("SCAN TAG");
+        while(!tagReader.isNewTagPresent()) {
+          M5.Lcd.print(".");
+        }
+        M5.Lcd.println("TAG DETECTED");
+        unsigned char buffer[10];
+        unsigned char size = tagReader.readTag(buffer);
+        if (size > 0) {
+          tag = "";
+          for (unsigned char i = 0; i < size; i++) {
+            char two[3];
+            sniprintf(two, sizeof(two), "%02x", buffer[i]);
+            tag += two;
+          }
+          LOG_INFO("[TAG] New Tag %s\n", tag.c_str());
+          M5.Lcd.println("TAG VALUE :");
+          M5.Lcd.println(tag);
+        }
+      } else if(buttons.BtnC->wasPressed()) {
+        M5.Lcd.println("STOP RFID");
+      }
+      if(buttons.BtnB->pressedFor(3000)) {
+        LOG_DEBUG("[MAINT.] Exit module %s\n",ACTIVE_MODULES[1]);
+        ctx->setMaintenanceActiveModule(ActiveModule::NONE);
+        // clearScreen();
+        M5.Lcd.clearDisplay();
+        M5.Lcd.setCursor(0,0);
+        M5.Lcd.println("Maintenance Mode");
+        M5.Lcd.println("A: < B: OK C: >");
+      }
     }
-  } while (interruptibleTaskPauseMs(100));
+  } while(interruptibleTaskPauseMs(TAG_READER_INTERVAL));
+}
+
+static void makeHttpRequests(TaskContext *ctx) {
+  Buttons &buttons = ctx->getHardware()->buttons;
+  WebConfigurator &webConfigurator = ctx->getHardware()->webConfigurator;
+  do {
+    if(ctx->getCurrentMaintenanceModule() == ActiveModule::DOLIBARR) {
+      buttons.update();
+      if(buttons.BtnA->wasPressed()) {
+        LOG_INFO("\n[HTTP] Starting!\n");
+        WiFiClass::mode(WIFI_STA);  // connect to access point
+        WiFi.begin(webConfigurator.getApSsid(), webConfigurator.getApPassword());
+        M5.Lcd.println("Connecting to WIFI");
+
+        while (WiFiClass::status() != WL_CONNECTED) {
+          if (!interruptibleTaskPauseMs(500)) {
+            LOG_DEBUG("[HTTP] Connection cancelled\n");
+            return;
+          }
+          M5.Lcd.print(".");
+        }
+      } else if(buttons.BtnC->wasPressed()) {
+        M5.Lcd.println("SEND PRODUCT REQUEST");
+        // TODO ML print the result
+      }
+
+      if(buttons.BtnB->pressedFor(3000)) {
+        LOG_DEBUG("[MAINT.] Exit module %s\n",ACTIVE_MODULES[1]);
+        ctx->setMaintenanceActiveModule(ActiveModule::NONE);
+        // clearScreen();
+        M5.Lcd.clearDisplay();
+        M5.Lcd.setCursor(0,0);
+        M5.Lcd.println("Maintenance Mode");
+        M5.Lcd.println("A: < B: OK C: >");
+      }
+    }
+  } while(interruptibleTaskPauseMs(BUTTONS_READ_INTERVAL));
+
 }
 
 void startMaintenanceMode(TaskContext *ctx) {
@@ -31,8 +243,29 @@ void startMaintenanceMode(TaskContext *ctx) {
 #ifdef ENV_M5STACK
   M5.Lcd.clearDisplay();
   M5.Lcd.setCursor(0, 0);
-  M5.Lcd.println("= FAKE Maintenance Mode =");
-  M5.Lcd.println("B: Mode");
+  M5.Lcd.println("= Maintenance Mode =");
+  M5.Lcd.println("A: < B: OK C: >");
+  // M5.Lcd.println("Hold B to change to configuration mode");
 #endif  // defined(ENV_M5STACK)
-  spawnSubTask(temporaryFakeMaintenanceModeTask, ctx);
+  ctx->setMaintenanceActiveModule(ActiveModule::NONE);
+  LOG_DEBUG("[MAINT.] Active Module : %s\n", ACTIVE_MODULES[static_cast<int>(ctx->getCurrentMaintenanceModule())]);
+  spawnSubTask(selectMode, ctx);
+  spawnSubTask(runConveyor, ctx);
+  spawnSubTask(startSorter, ctx);
+  spawnSubTask(readAndPrintTags, ctx);
+  spawnSubTask(makeHttpRequests, ctx);
 }
+
+// void exitModule() {
+//   LOG_DEBUG("[MAINT.] Exit module \n");
+//   maintenance.changeModule(static_cast<int>(ActiveModule::NONE));
+//   maintenance.changeRange(0, false);
+//   // clearScreen();
+//   M5.Lcd.println("Maintenance Mode");
+//   M5.Lcd.println("A: < B: OK C: >");
+// }
+
+// static void clearScreen() {
+//   M5.Lcd.clearDisplay();
+//   M5.Lcd.setCursor(0,0);
+// }

--- a/src/maintenance.cpp
+++ b/src/maintenance.cpp
@@ -4,6 +4,8 @@
 
 #ifdef ENV_M5STACK
 #include <M5Stack.h>
+
+#include <lcdScreen.hpp>
 #endif  // defined(ENV_M5STACK)
 
 #include <TaskContext.hpp>
@@ -15,11 +17,6 @@
 #include "TheTranslationConfig.hpp"
 #include "taskUtil.hpp"
 #ifdef ENV_M5STACK
-void clearScreen() {
-  M5.Lcd.clearDisplay();
-  M5.Lcd.setCursor(0, 0); 
-}
-
 void showMenu() {
   M5.Lcd.println("Maintenance Mode");
   M5.Lcd.println("A: < B: OK C: >");


### PR DESCRIPTION
Maintenance mode set up, accessible after production mode.

Each module can be launch individually:
- select a module (CONVEYOR, SORTER, TAG_READER, or DOLIBARR) by clicking on button A or C
- then, valid with the button B.
- exit the Maintenance Mode by holding the button C.

Some module properties can be tested, those will be detailled in the maintenance manual shortly

closed #24 
