### PR TITLE
Set a default position for the sorter servomotor

### DIFF
--- a/src/Sorter.cpp
+++ b/src/Sorter.cpp
@@ -9,7 +9,7 @@ GoPlus2 goPlus;
 void Sorter::begin() {
   goPlus.begin();
   goPlus.Servo_write_plusewidth(SORTER_SERVO_NUMBER, SORTER_SERVO_PULSE_WIDTH);
-  goPlus.Servo_write_angle(SORTER_SERVO_NUMBER, SORTER_SERVO_MIDDLE_ANGLE);
+  goPlus.Servo_write_angle(SORTER_SERVO_NUMBER, SORTER_SERVO_RIGHT_ANGLE);
 }
 
 void Sorter::move(SorterDirection direction) {

--- a/src/Sorter.cpp
+++ b/src/Sorter.cpp
@@ -9,7 +9,7 @@ GoPlus2 goPlus;
 void Sorter::begin() {
   goPlus.begin();
   goPlus.Servo_write_plusewidth(SORTER_SERVO_NUMBER, SORTER_SERVO_PULSE_WIDTH);
-  goPlus.Servo_write_angle(SORTER_SERVO_NUMBER, SORTER_SERVO_RIGHT_ANGLE);
+  move(SorterDirection::RIGHT);
 }
 
 void Sorter::move(SorterDirection direction) {

--- a/src/Sorter.cpp
+++ b/src/Sorter.cpp
@@ -9,6 +9,7 @@ GoPlus2 goPlus;
 void Sorter::begin() {
   goPlus.begin();
   goPlus.Servo_write_plusewidth(SORTER_SERVO_NUMBER, SORTER_SERVO_PULSE_WIDTH);
+  goPlus.Servo_write_angle(SORTER_SERVO_NUMBER, SORTER_SERVO_RIGHT_ANGLE);
 }
 
 void Sorter::move(SorterDirection direction) {

--- a/src/Sorter.cpp
+++ b/src/Sorter.cpp
@@ -9,7 +9,7 @@ GoPlus2 goPlus;
 void Sorter::begin() {
   goPlus.begin();
   goPlus.Servo_write_plusewidth(SORTER_SERVO_NUMBER, SORTER_SERVO_PULSE_WIDTH);
-  goPlus.Servo_write_angle(SORTER_SERVO_NUMBER, SORTER_SERVO_RIGHT_ANGLE);
+  goPlus.Servo_write_angle(SORTER_SERVO_NUMBER, SORTER_SERVO_MIDDLE_ANGLE);
 }
 
 void Sorter::move(SorterDirection direction) {


### PR DESCRIPTION
The servomotor took up an undesirable position when the system started up. 
A middle position has been defined.

![image](https://github.com/user-attachments/assets/71b74116-58a3-4a22-b4a0-2ce2187775f7)
