### PR TITLE
Detect when products are stuck with the tag reader

### DIFF
--- a/include/TagReader.hpp
+++ b/include/TagReader.hpp
@@ -25,9 +25,12 @@ class TagReader {
 
   TagReaderStatus getStatus();
 
+  void setIsStuck(const bool isStuck);
+
  private:
   MFRC522_I2C *m_mfrc522;
   TagReaderStatus m_status;
+  bool m_isStuck;
 };
 
 #endif  // !defined(TAG_READER_HPP)

--- a/include/TagReader.hpp
+++ b/include/TagReader.hpp
@@ -25,6 +25,7 @@ class TagReader {
 
   TagReaderStatus getStatus();
 
+  bool isStuck();
   void setIsStuck(const bool isStuck);
 
  private:

--- a/include/TheTranslationConfig.hpp
+++ b/include/TheTranslationConfig.hpp
@@ -32,7 +32,7 @@
 
 #pragma region "tag reader configuration"
 #define TAG_READER_INTERVAL 100              //< Read interval in milliseconds
-#define TAG_READER_TEST_INTERVAL 1000 * 5   //< Test interval in milliseconds
+#define TAG_READER_TEST_INTERVAL 1000 * 5    //< Test interval in milliseconds
 #define TAG_READER_MAX_CONSECUTIVE_READS 10  //< maximum number of consecutive reads before considering a product stuck
 #pragma endregion "tag reader configuration"
 

--- a/include/TheTranslationConfig.hpp
+++ b/include/TheTranslationConfig.hpp
@@ -31,9 +31,10 @@
 #pragma endregion "M5 LCD screen configuration"
 
 #pragma region "tag reader configuration"
-#define TAG_READER_INTERVAL 100              //< Read interval in milliseconds
-#define TAG_READER_TEST_INTERVAL 1000 * 5    //< Test interval in milliseconds
-#define TAG_READER_MAX_CONSECUTIVE_READS 10  //< maximum number of consecutive reads before considering a product stuck
+#define TAG_READER_INTERVAL 100                                      //< Read interval in milliseconds
+#define TAG_READER_TEST_INTERVAL 1000 * 5                            //< Test interval in milliseconds
+#define TAG_READER_MIN_CONSECUTIVE_INTERVAL TAG_READER_INTERVAL * 3  //< Minimal interval between reads
+#define TAG_READER_MAX_CONSECUTIVE_READS 10  //< Maximum number of consecutive reads before considering a product stuck
 #pragma endregion "tag reader configuration"
 
 #pragma region "soft access point configuration"

--- a/include/TheTranslationConfig.hpp
+++ b/include/TheTranslationConfig.hpp
@@ -31,8 +31,9 @@
 #pragma endregion "M5 LCD screen configuration"
 
 #pragma region "tag reader configuration"
-#define TAG_READER_INTERVAL 100             //< Read interval in milliseconds
-#define TAG_READER_TEST_INTERVAL 1000 * 60  //< Test interval in milliseconds
+#define TAG_READER_INTERVAL 100              //< Read interval in milliseconds
+#define TAG_READER_TEST_INTERVAL 1000 * 5   //< Test interval in milliseconds
+#define TAG_READER_MAX_CONSECUTIVE_READS 10  //< maximum number of consecutive reads before considering a product stuck
 #pragma endregion "tag reader configuration"
 
 #pragma region "soft access point configuration"

--- a/simulator-gui/src/gui.cpp
+++ b/simulator-gui/src/gui.cpp
@@ -3,6 +3,9 @@
 #include "sim/Configuration.hpp"
 #include "sim/HardwareState.hpp"
 
+#define TAG_READER_I2C_BUS 1
+#define EOL_READER_I2C_BUS 1
+
 static void helpMarker(const char *desc) {
   ImGui::SameLine();
   ImGui::TextDisabled("(?)");
@@ -71,10 +74,10 @@ static void hardwareSectionTagReader(sim::Client &client, sim::HardwareState &hw
   ImGui::InputScalar("Version", ImGuiDataType_U8, &hw.tagReaderVersion, nullptr, nullptr, "%x", 0);
   if (ImGui::Button("Send")) {
     if (hw.tagReaderUid == 0) {
-      client.sendNfcSetCard(I2CAddress{0, 0x28}, "", 0);
+      client.sendNfcSetCard(I2CAddress{TAG_READER_I2C_BUS, 0x28}, "", 0);
     } else {
       std::vector<char> uid = uint64ToBigEndianBytes(hw.tagReaderUid);
-      client.sendNfcSetCard(I2CAddress{0, 0x28}, uid.data(), uid.size());
+      client.sendNfcSetCard(I2CAddress{TAG_READER_I2C_BUS, 0x28}, uid.data(), uid.size());
     }
   }
   ImGui::SameLine();
@@ -89,10 +92,10 @@ static void hardwareSectionEndOfLineReader(sim::Client &client, sim::HardwareSta
   ImGui::InputScalar("Version", ImGuiDataType_U8, &hw.tagReaderVersion, nullptr, nullptr, "%x", 0);
   if (ImGui::Button("Send")) {
     if (hw.tagReaderUid == 0) {
-      client.sendNfcSetCard(I2CAddress{1, 0x28}, "", 0);
+      client.sendNfcSetCard(I2CAddress{EOL_READER_I2C_BUS, 0x28}, "", 0);
     } else {
       std::vector<char> uid = uint64ToBigEndianBytes(hw.tagReaderUid);
-      client.sendNfcSetCard(I2CAddress{1, 0x28}, uid.data(), uid.size());
+      client.sendNfcSetCard(I2CAddress{EOL_READER_I2C_BUS, 0x28}, uid.data(), uid.size());
     }
   }
   ImGui::SameLine();

--- a/simulator-gui/src/main.cpp
+++ b/simulator-gui/src/main.cpp
@@ -89,7 +89,7 @@ static void registerHandlers(sim::Controller &ctrl, Dimensions *d, Image *screen
   ctrl.onReceive(S2COpcode::HTTP_END,
                  [](sim::Controller &c, S2CMessage const &msg) { c.getHardwareState().httpProxy.end(msg.httpEnd.reqId, c.getClient()); });
   ctrl.onReceive(S2COpcode::NFC_GET_VERSION, [](sim::Controller &c, S2CMessage const &) {
-    if (c.getHardwareState().tagReaderEnabled) c.getClient().sendNfcSetVersion(I2CAddress{0, 0x28}, c.getHardwareState().tagReaderVersion);
+    if (c.getHardwareState().tagReaderEnabled) c.getClient().sendNfcSetVersion(I2CAddress{1, 0x28}, c.getHardwareState().tagReaderVersion);
   });
   ctrl.onReceive(S2COpcode::SORTER_SET_ANGLE, [](sim::Controller &c, S2CMessage const &msg) {
     if (c.getHardwareState().sorterEnabled) c.getHardwareState().sorterAngle = msg.sorterSetAngle;

--- a/src/TagReader.cpp
+++ b/src/TagReader.cpp
@@ -46,4 +46,6 @@ void TagReader::selfTest() {
 
 TagReaderStatus TagReader::getStatus() { return m_status; }
 
+bool TagReader::isStuck() { return m_isStuck; }
+
 void TagReader::setIsStuck(const bool isStuck) { m_isStuck = isStuck; }

--- a/src/TagReader.cpp
+++ b/src/TagReader.cpp
@@ -1,6 +1,7 @@
 #include "TagReader.hpp"
 
 void TagReader::begin(TwoWire *wire) {
+  m_isStuck = false;
   m_status = TagReaderStatus::CONFIGURING;
   m_mfrc522 = new MFRC522_I2C(0x28, 0, wire);
   m_mfrc522->PCD_Init();
@@ -22,6 +23,11 @@ unsigned char TagReader::readTag(unsigned char *buffer) {
 }
 
 void TagReader::selfTest() {
+  if (m_isStuck) {
+    m_status = TagReaderStatus::ERROR;
+    return;
+  }
+
   m_status = TagReaderStatus::CONFIGURING;
   byte version = m_mfrc522->PCD_ReadRegister(MFRC522_I2C::PCD_Register::VersionReg);
   switch (version) {
@@ -39,3 +45,5 @@ void TagReader::selfTest() {
 }
 
 TagReaderStatus TagReader::getStatus() { return m_status; }
+
+void TagReader::setIsStuck(const bool isStuck) { m_isStuck = isStuck; }

--- a/src/production.cpp
+++ b/src/production.cpp
@@ -24,6 +24,7 @@ static void readButtons(TaskContext *ctx) {
       LOG_DEBUG("[BTN] A pressed\n");
       conveyor.start();
       tagReader.setIsStuck(false);
+      tagReader.selfTest();
     } else if (buttons.BtnC->wasPressed()) {
       LOG_DEBUG("[BTN] C pressed\n");
       conveyor.stop();
@@ -64,9 +65,9 @@ static void readTagsAndRunConveyor(TaskContext *ctx) {
 
         if (tagReader.isNewTagPresent()) {
           const int currentTick = millis();
-          LOG_TRACE("[TAG] lastTagReadTick %u ; currentTick %u\n", lastTagReadTick, currentTick);
+          LOG_TRACE("[TAG] lastTagReadTick %u ; currentTick %u, delta %u\n", lastTagReadTick, currentTick, currentTick - lastTagReadTick);
 
-          if (lastTagReadTick + TAG_READER_INTERVAL * 2 <= currentTick) {
+          if (currentTick - lastTagReadTick > TAG_READER_MIN_CONSECUTIVE_INTERVAL) {
             consecutiveTagRead = 0;
 
             unsigned char buffer[10];

--- a/src/production.cpp
+++ b/src/production.cpp
@@ -86,10 +86,12 @@ static void readTagsAndRunConveyor(TaskContext *ctx) {
               LOG_INFO("[TAG] New Tag %s\n", tag.c_str());
             }
           } else {
-            consecutiveTagRead++;
-            if (consecutiveTagRead >= TAG_READER_MAX_CONSECUTIVE_READS) {
-              LOG_ERROR("[TAG] A product is stuck!\n");
-              tagReader.setIsStuck(true);
+            if (!tagReader.isStuck()) {
+              consecutiveTagRead++;
+              if (consecutiveTagRead >= TAG_READER_MAX_CONSECUTIVE_READS) {
+                LOG_ERROR("[TAG] A product is stuck!\n");
+                tagReader.setIsStuck(true);
+              }
             }
           }
           lastTagReadTick = currentTick;


### PR DESCRIPTION
How it works:

- When a package is detected too quickly, it is ignored
- If that's too frequent (10 times by default), tag reader passes in error state
- When incident is resolved, a human person must press A to restart the conveyor

How to test with the simulator:

- Increasing the value `TAG_READER_INTERVAL` in `TheTranslationConfig.hpp` and spam sending with the tag reader

Closes #63 