### PR TITLE
Add a screen to show machines' state

### DIFF
--- a/include/Conveyor.hpp
+++ b/include/Conveyor.hpp
@@ -14,6 +14,7 @@ static constexpr char const *CONVEYOR_STATUS_STRINGS[] = {
     "UNDEFINED",
     "STOPPED",
     "RUNNING",
+    "CANCELLED",
 };
 
 /// @brief Conveyor interface

--- a/include/DolibarrClient.hpp
+++ b/include/DolibarrClient.hpp
@@ -3,7 +3,19 @@
 
 #include <HTTPClient.h>
 
-enum class DolibarrClientStatus { CONFIGURING = 0, READY, SENDING, ERROR };
+enum class DolibarrClientStatus {
+  CONFIGURING = 0,
+  READY,
+  SENDING,
+  ERROR,
+};
+
+static constexpr char const* DOLIBARR_CLIENT_STATUS_STRINGS[] = {
+    "CONFIGURING",
+    "READY",
+    "SENDING",
+    "ERROR",
+};
 
 class DolibarrClient {
  public:

--- a/include/Sorter.hpp
+++ b/include/Sorter.hpp
@@ -7,6 +7,13 @@ enum class SorterDirection {
   RIGHT,
 };
 
+static constexpr char const *SORTER_DIRECTIONS[] = {
+    "(nothing)",
+    "LEFT",
+    "MIDDLE",
+    "RIGHT",
+};
+
 /// @brief The package sorter, usually driven by a servo motor.
 class Sorter {
  public:
@@ -17,6 +24,7 @@ class Sorter {
   void moveWithSpecificAngle(int angle);
   int getCurrentAngle() const;
   int getDesiredAngle() const;
+  SorterDirection getDesiredDirection() const;
   void setDesiredAngle(SorterDirection direction);
 
  private:

--- a/include/TagReader.hpp
+++ b/include/TagReader.hpp
@@ -3,7 +3,17 @@
 
 #include <MFRC522_I2C.h>
 
-enum class TagReaderStatus { CONFIGURING, READY, ERROR };
+enum class TagReaderStatus {
+  CONFIGURING,
+  READY,
+  ERROR,
+};
+
+static constexpr char const *TAGREADER_STATUS_STRINGS[] = {
+    "CONFIGURING",
+    "READY",
+    "ERROR",
+};
 
 class TagReader {
  public:

--- a/include/lcdScreen.hpp
+++ b/include/lcdScreen.hpp
@@ -1,13 +1,17 @@
 #ifndef LCD_SCREEN_HPP
 #define LCD_SCREEN_HPP
 
+#include "Conveyor.hpp"
+#include "DolibarrClient.hpp"
+#include "Sorter.hpp"
+#include "TagReader.hpp"
 #include "WebConfigurator.hpp"
 
 void clearScreen();
 
 void printConfiguration(WebConfigurator& conf);
 
-void printProductionStatus();
+void printProductionStatus(DolibarrClientStatus dolibarr, ConveyorStatus conveyor, TagReaderStatus tagReader, SorterDirection sorter);
 
 void printLogScreen();
 

--- a/src/Sorter.cpp
+++ b/src/Sorter.cpp
@@ -22,6 +22,19 @@ int Sorter::getCurrentAngle() const { return m_currentAngle; }
 
 int Sorter::getDesiredAngle() const { return m_desiredAngle; }
 
+SorterDirection Sorter::getDesiredDirection() const {
+  switch (m_desiredAngle) {
+    case SORTER_SERVO_LEFT_ANGLE:
+      return SorterDirection::LEFT;
+    case SORTER_SERVO_MIDDLE_ANGLE:
+      return SorterDirection::MIDDLE;
+    case SORTER_SERVO_RIGHT_ANGLE:
+      return SorterDirection::RIGHT;
+    default:
+      return SorterDirection::RIGHT;
+  }
+}
+
 void Sorter::setDesiredAngle(SorterDirection direction) {
   switch (direction) {
     case SorterDirection::LEFT:

--- a/src/lcdScreen.cpp
+++ b/src/lcdScreen.cpp
@@ -45,8 +45,20 @@ void printConfiguration(WebConfigurator& conf) {
   M5.Lcd.setTextSize(SCREEN_FONT_SIZE);
 }
 
-void printProductionStatus() {
-  // TODO
+void printProductionStatus(DolibarrClientStatus dolibarr, ConveyorStatus conveyor, TagReaderStatus tagReader, SorterDirection sorter) {
+  M5.Lcd.println();
+
+  M5.Lcd.print("Dolibarr client status : ");
+  M5.Lcd.println(DOLIBARR_CLIENT_STATUS_STRINGS[static_cast<int>(dolibarr)]);
+
+  M5.Lcd.print("Conveyor status : ");
+  M5.Lcd.println(CONVEYOR_STATUS_STRINGS[static_cast<int>(conveyor)]);
+
+  M5.Lcd.print("TagReader status : ");
+  M5.Lcd.println(TAGREADER_STATUS_STRINGS[static_cast<int>(tagReader)]);
+
+  M5.Lcd.print("Sorter direction : ");
+  M5.Lcd.println(SORTER_DIRECTIONS[static_cast<int>(sorter)]);
 }
 
 void printLogScreen() {

--- a/test/test_spawn.cpp
+++ b/test/test_spawn.cpp
@@ -22,13 +22,13 @@ TEST_CASE("Spawn TheTranslation") {
   REQUIRE_MESSAGE(ctrl->awaitConnection(), "Failed to connect to the server, timed out");
 
   SUBCASE("Production mode - start and stop conveyor") {
-    // Conveyor should start when 'A' is pressed
+    // Conveyor should start when 'A' is pressed (first time)
     bool started = ctrl->expectReceive(S2COpcode::CONVEYOR_SET_SPEED, [ctrl] { ctrl->pressButton(0); }, &message);
     REQUIRE_UNARY(started);
     CHECK_GT(message.conveyorSetSpeed, 0);
 
-    // Conveyor should stop when 'C' is pressed
-    bool stopped = ctrl->expectReceive(S2COpcode::CONVEYOR_SET_SPEED, [ctrl] { ctrl->pressButton(2); }, &message);
+    // Conveyor should stop when 'A' is pressed (second time)
+    bool stopped = ctrl->expectReceive(S2COpcode::CONVEYOR_SET_SPEED, [ctrl] { ctrl->pressButton(0); }, &message);
     REQUIRE_UNARY(stopped);
     CHECK_EQ(message.conveyorSetSpeed, 0);
   }


### PR DESCRIPTION
Changes in production buttons' logic:

- Button A is used to start/stop
- Button C is used to show/hide states

Some possible improvements :

- use colored printing
- show EOL sensor state (needs #67 )

Closes #15 